### PR TITLE
Cleanup temporary files before processing a new image.

### DIFF
--- a/i.fusion.hpf.py
+++ b/i.fusion.hpf.py
@@ -175,27 +175,32 @@
 #% required: no
 #%end
 
-# required librairies
-
+# StdLib imports
 import os
 import sys
-sys.path.insert(1, os.path.join(os.path.dirname(sys.path[0]),
-                                'etc', 'i.fusion.hpf'))
 import atexit
 
-import grass.script as grass
-from grass.pygrass.modules.shortcuts import general as g
-from grass.pygrass.raster.abstract import Info
-
-from high_pass_filter import High_Pass_Filter
-
+# Make sure that we are within a GRASS context
 if "GISBASE" not in os.environ:
     print "You must be in GRASS GIS to run this program."
     sys.exit(1)
 
+# GRASS imports
+import grass.script as grass
+from grass.pygrass.modules.shortcuts import general as g
+from grass.pygrass.raster.abstract import Info
+from grass.pygrass.utils import get_lib_path
+
+# Add the "etc" directory to the $PATH
+path = get_lib_path("i.fusion.hpf", "")
+if path is None:
+    raise ImportError("Not able to find the path %s directory." % path)
+sys.path.append(path)
+
+# We can now import the modules from "etc"
+from high_pass_filter import High_Pass_Filter
 
 # globals
-
 ratio = float()
 tmp = ''
 tmp_hpf_matrix = ''

--- a/i.fusion.hpf.py
+++ b/i.fusion.hpf.py
@@ -587,6 +587,9 @@ def main():
         msx_name = msx_name.format(base=msx.split('@')[0], suffix=outputsuffix)
         run("g.rename", raster=(tmp_msx_hpf, msx_name))
 
+        # remove temporary files
+        cleanup()
+
     # visualising-related information
     grass.del_temp_region()  # restoring previous region settings
     g.message("\n|! Original Region restored")

--- a/i.fusion.hpf.py
+++ b/i.fusion.hpf.py
@@ -210,16 +210,16 @@ modulator_2 = float()
 
 # helper functions
 
-def cleanup():
-    """Clean up temporary maps"""
-    grass.run_command('g.remove', flags='f', type="raster",
-                      pattern='tmp.{pid}*'.format(pid=os.getpid(), quiet=True))
-
-
 def run(cmd, **kwargs):
     """Pass arbitrary number of key-word arguments to grass commands and the
     "quiet" flag by default."""
     grass.run_command(cmd, quiet=True, **kwargs)
+
+
+def cleanup():
+    """Clean up temporary maps"""
+    pattern = 'tmp.{pid}*'.format(pid=os.getpid())
+    run('g.remove', flags="f", type="raster", pattern=pattern)
 
 
 def avg(img):


### PR DESCRIPTION
while using the script I run out of disk space. With the last commit we remove the temporary raster maps as soon as they are not needed any more.

The other too commits are just a tiny bit of refactoring + a minor bug fix.